### PR TITLE
Add 'is_verify' flag for posts on the feed

### DIFF
--- a/api/src/Controllers/BoardsFetcher.php
+++ b/api/src/Controllers/BoardsFetcher.php
@@ -40,27 +40,33 @@ class BoardsFetcher
         $limit        = $req->getParams('limit') ? $req->getParams('limit') : 20;
         $offset       = $req->getParams('offset') ? $req->getParams('offset') : 0;
 
-        $results['posts'] = $this->db->select(
-            'posts',
-            [
-                '[>]boards' => [
-                    'board_id' => 'id'
-                ]
-            ],
-            [
-                'posts.id',
-                'posts.poster',
-                'posts.subject',
-                'posts.message',
-                'posts.timestamp',
-                'posts.parent_id',
-                'boards.tag'
-            ],
-            [
-                'AND' => ['boards.tag[!]' => $exclude_tags],
-                'LIMIT' => [$offset, $limit],
-                'ORDER' => ['posts.timestamp' => 'DESC']
-            ]
+        $results['posts'] = array_map(function ($post) {
+            $post['is_verify'] = ($post['is_verify'] === 'yes' ? true : false);
+            return $post;
+          },
+          $this->db->select(
+              'posts',
+              [
+                  '[>]boards' => [
+                      'board_id' => 'id'
+                  ]
+              ],
+              [
+                  'posts.id',
+                  'posts.poster',
+                  'posts.subject',
+                  'posts.message',
+                  'posts.timestamp',
+                  'posts.parent_id',
+                  'posts.is_verify',
+                  'boards.tag'
+              ],
+              [
+                  'AND' => ['boards.tag[!]' => $exclude_tags],
+                  'LIMIT' => [$offset, $limit],
+                  'ORDER' => ['posts.timestamp' => 'DESC']
+              ]
+          )
         );
 
         return new Response($results, 200);


### PR DESCRIPTION
По сути фиксит https://github.com/U-Me-Chan/pissykaka/issues/2

Я решил, что хочу попробовать сделать это сам и даже получилось разобраться и протестировать на локально запущенном инстансе, используя старые летние дампы прода.

Я посмотрел как это сделано в современном коде, то есть в `api/src/Database/PostRepository.php` и увидел, что там ремапинг `"yes"`/`"no"` в `true`/`false` и наоборот делается средствами PHP, а не средствами SQL, поэтому сделал тоже в PHP. Если честно, я не уверен, что через Medoo можно использовать такие фичи SQL как `case when end`, что является [возможным вариантом такого ремапинга](https://stackoverflow.com/questions/38567366/mapping-values-in-sql-select).