### PR TITLE
Чан: Frontend: Board: Исправление дефектов отображения обьектов визуального обособления пагинаторов от основного контента борды

### DIFF
--- a/frontend/src/components/Board.vue
+++ b/frontend/src/components/Board.vue
@@ -44,7 +44,10 @@
     </section>
   </div>
 
+  <hr v-if="isContentExist">
+
   <b-pagination
+    class="board-paginator"
     v-if="isContentExist"
     :total="count"
     :current="current"
@@ -184,5 +187,9 @@ hr {
 .card {
     margin: 5px;
     padding: 10px;
+}
+
+.board-paginator {
+  margin-bottom: unset;
 }
 </style>


### PR DESCRIPTION
1. Пагинатор возле хэдера - содержит излишний margin-bottom
![image](https://github.com/user-attachments/assets/4f3f9f1f-d452-4050-a14a-199ff921c8f9)

2. Пагинатор возле футера - не содержит верхнего <hr>
![image](https://github.com/user-attachments/assets/34b76b1c-2eb2-4bf9-8542-7b29b229652f)
