### PR TITLE
Чан: Frontend: Board: Исправлено наличие дефолтного margin-bottom у верхнего пагинатора борды

### DIFF
--- a/frontend/src/components/Board.vue
+++ b/frontend/src/components/Board.vue
@@ -11,6 +11,7 @@
   <hr v-if="isContentExist">
 
   <b-pagination
+    class="board-paginator"
     v-if="isContentExist"
     :total="count"
     :current="current"


### PR DESCRIPTION
1. Пагинатор возле хэдера - содержит излишний margin-bottom
![image](https://github.com/user-attachments/assets/4f3f9f1f-d452-4050-a14a-199ff921c8f9)
