### PR TITLE
Frontend: Визуальные исправления стадии загрузки контента страницы при первом открытии

### DIFF
--- a/frontend/src/components/App.vue
+++ b/frontend/src/components/App.vue
@@ -150,9 +150,12 @@ p {
 
 .auth-panel-wrap,
 .radios-panel-wrap,
-.footer-wrap,
 .board-list {
     background-color: #fafafa;
+}
+
+.footer-wrap {
+    background: linear-gradient(180deg, #fafafa 0%, #ffffff 100%)
 }
 
 .main-content,

--- a/frontend/src/components/App.vue
+++ b/frontend/src/components/App.vue
@@ -137,6 +137,7 @@ p {
     display:flex;
     justify-content: space-around;
     flex-wrap: wrap;
+    min-height: 36px;
 }
 
 .board-link {


### PR DESCRIPTION
Как было: (нулевая высота борд-листа, цветовая ступенька между футером и линией конца контента окна.
![image](https://github.com/user-attachments/assets/4291e008-ed07-4cb2-9e15-30f6941f263b)

Как станет:
![image](https://github.com/user-attachments/assets/52b09f11-c19a-496f-a9a6-e12d0376a182)
